### PR TITLE
feat: add toggle for context tokens (key 'c')

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -16,6 +16,7 @@ pub struct App {
     outline_selection: usize,
     show_help: bool,
     context_width: usize,
+    pub context_enabled: bool,
     pub hint_chars_enabled: bool,
     pub styling_enabled: bool,
 }
@@ -25,7 +26,7 @@ pub const DEFAULT_CONTEXT_WIDTH: usize = 100;
 
 impl App {
     pub fn new(tokens: Vec<TimedToken>, sections: Vec<Section>) -> Self {
-        Self::with_options(tokens, sections, DEFAULT_CONTEXT_WIDTH, true, true)
+        Self::with_options(tokens, sections, DEFAULT_CONTEXT_WIDTH, true, true, true)
     }
 
     pub fn with_context_width(
@@ -33,7 +34,7 @@ impl App {
         sections: Vec<Section>,
         context_width: usize,
     ) -> Self {
-        Self::with_options(tokens, sections, context_width, true, true)
+        Self::with_options(tokens, sections, context_width, true, true, true)
     }
 
     pub fn with_options(
@@ -42,6 +43,7 @@ impl App {
         context_width: usize,
         hint_chars_enabled: bool,
         styling_enabled: bool,
+        context_enabled: bool,
     ) -> Self {
         Self {
             tokens,
@@ -53,6 +55,7 @@ impl App {
             outline_selection: 0,
             show_help: false,
             context_width,
+            context_enabled,
             hint_chars_enabled,
             styling_enabled,
         }
@@ -161,9 +164,19 @@ impl App {
         self.show_help = !self.show_help;
     }
 
+    /// Toggle visibility of context tokens (above/below RSVP line)
+    pub fn toggle_context_tokens(&mut self) {
+        self.context_enabled = !self.context_enabled;
+    }
+
     #[must_use]
     pub const fn context_width(&self) -> usize {
         self.context_width
+    }
+
+    #[must_use]
+    pub const fn context_enabled(&self) -> bool {
+        self.context_enabled
     }
 
     #[must_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         cli.context_width,
         !cli.no_hint_chars,
         !cli.no_styling,
+        true, // context enabled by default
     );
 
     // Setup terminal
@@ -179,6 +180,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             app.skip_sentence()
                         }
                         (ViewMode::Reading, KeyCode::Char('o')) => app.toggle_outline(),
+                        (ViewMode::Reading, KeyCode::Char('c')) => app.toggle_context_tokens(),
 
                         // Outline mode
                         (ViewMode::Outline, KeyCode::Char('j') | KeyCode::Down) => {

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -32,6 +32,7 @@ pub fn render(frame: &mut Frame, area: Rect) {
         Line::from("h/Left    Rewind sentence"),
         Line::from("l/Right   Skip sentence"),
         Line::from("o         Toggle outline"),
+        Line::from("c         Toggle context"),
         Line::from("q         Quit"),
         Line::from("?         Toggle help"),
         Line::from(""),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -69,7 +69,12 @@ fn render_reading_view(frame: &mut Frame, app: &App, area: ratatui::layout::Rect
         ])
         .split(content_area);
 
-    context::render_before(frame, app, chunks[0], gutter_area);
+    // Render context only when enabled
+    if app.context_enabled() {
+        context::render_before(frame, app, chunks[0], gutter_area);
+    }
     rsvp::render(frame, app, chunks[1], gutter_area);
-    context::render_after(frame, app, chunks[2], gutter_area);
+    if app.context_enabled() {
+        context::render_after(frame, app, chunks[2], gutter_area);
+    }
 }


### PR DESCRIPTION
Description
---
Add a runtime toggle to show/hide the context lines (tokens above/below the RSVP word), a `c` keybinding to toggle it while reading, and a help overlay entry for the new shortcut.

Why
---
- Allows users to quickly hide context lines to focus on the single-word RSVP display (especially useful at high wpm speed).

What changed
---
- Added `context_enabled` state to `App` with a getter and toggle method.
- Respect `context_enabled` during UI rendering so the context panes are not drawn when disabled.
- Added `c` keybinding in Reading mode to toggle context visibility.
- Updated the help overlay to include the new `c` shortcut.

Files modified
---
- app.rs
  - Added field: `pub context_enabled: bool`.
  - Updated constructors (`new`, `with_context_width`, `with_options`) to accept/set `context_enabled`.
  - Added method: `pub fn toggle_context_tokens(&mut self)`.
  - Added getter: `pub const fn context_enabled(&self) -> bool`.
- mod.rs
  - Only render `context::render_before` and `context::render_after` when `app.context_enabled()` is true.
- help.rs
  - Added help entry: `c         Toggle context`.
- main.rs
  - `App::with_options(...)` call updated with `true` (context enabled by default).
  - Added input match arm:
    `(ViewMode::Reading, KeyCode::Char('c')) => app.toggle_context_tokens(),`

Implementation details
---
- Default behavior: context enabled by default. This matches previous behavior where context was always shown.
- The new toggle only affects rendering; it does not mutate tokens or underlying document state.